### PR TITLE
Set PREFIX through ARG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ ENV \
 RUN yum makecache fast
 RUN yum install -y automake16 libpng-devel nasm
 
-ENV PREFIX /var/task
+ARG PREFIX=/var/task
+
+ENV PREFIX=$PREFIX
 
 # versions of packages
 ENV \


### PR DESCRIPTION
Allow setting the prefix through a build-time argument, defaulting to /var/task. This feature is especially helpful in situations where you need /var/task in the container's file system to be available. For example, if a downstream application is hardcoded to mount a volume to that path, we can rebuild the container using this Dockerfile and simply pass --build-arg PREFIX=/var/gdal to docker build.

Since the ARG's default is set to /var/task, it shouldn't break any build toolchains.